### PR TITLE
Fixed typo: dyanmic -> dynamic

### DIFF
--- a/ImpromptuInterface/src/Dynamic/ImpromptuForwarder.cs
+++ b/ImpromptuInterface/src/Dynamic/ImpromptuForwarder.cs
@@ -98,8 +98,8 @@ namespace ImpromptuInterface.Dynamic
         {
             if (!KnownInterfaces.Any())
             {
-                var tDyanmic = Impromptu.GetMemberNames(CallTarget, dynamicOnly: true);
-                if (!tDyanmic.Any())
+                var tDynamic = Impromptu.GetMemberNames(CallTarget, dynamicOnly: true);
+                if (!tDynamic.Any())
                 {
                     return Impromptu.GetMemberNames(CallTarget);
                 }

--- a/ImpromptuInterface/src/Dynamic/ImpromptuObject.cs
+++ b/ImpromptuInterface/src/Dynamic/ImpromptuObject.cs
@@ -201,7 +201,7 @@ namespace ImpromptuInterface.Dynamic
 
 
         /// <summary>
-        /// Allows ActLike to be called via dyanmic invocation
+        /// Allows ActLike to be called via dynamic invocation
         /// </summary>
         /// <typeparam name="TInterface">The type of the interface.</typeparam>
         /// <param name="otherInterfaces">The other interfaces.</param>

--- a/ImpromptuInterface/src/Impromptu.cs
+++ b/ImpromptuInterface/src/Impromptu.cs
@@ -1146,7 +1146,7 @@ namespace ImpromptuInterface
         }
 
         /// <summary>
-        /// Static Method that wraps an existing dyanmic object with a explicit interface type
+        /// Static Method that wraps an existing dynamic object with a explicit interface type
         /// </summary>
         /// <param name="originalDynamic">The original dynamic.</param>
         /// <param name="otherInterfaces">The other interfaces.</param>

--- a/Tests/UnitTestImpromptuInterface.VBNet/SingleMethodInvoke.vb
+++ b/Tests/UnitTestImpromptuInterface.VBNet/SingleMethodInvoke.vb
@@ -64,7 +64,7 @@ Namespace VBNET
         End Sub
 
         <Test()> _
-        Public Sub TestCacheableDyanmicSetAndPocoSetAndSetNull()
+        Public Sub TestCacheableDynamicSetAndPocoSetAndSetNull()
             Dim tExpando As Object = New ExpandoObject()
             Dim tSetValueD = "4"
 
@@ -828,37 +828,37 @@ Namespace VBNET
 
         <Test()> _
         Public Sub TestDynamicAddAssign()
-            Dim tDyanmic = Build.NewObject(Prop2:=3, [Event]:=Nothing, OnEvent:=New ThisAction(Of Object, EventArgs)(Function(this, obj, args) this.[Event](obj, args)))
+            Dim tDynamic = Build.NewObject(Prop2:=3, [Event]:=Nothing, OnEvent:=New ThisAction(Of Object, EventArgs)(Function(this, obj, args) this.[Event](obj, args)))
             Dim tTest As Boolean = False
 
-            Impromptu.InvokeAddAssign(tDyanmic, "Event", New EventHandler(Of EventArgs)(Function([object], args)
+            Impromptu.InvokeAddAssign(tDynamic, "Event", New EventHandler(Of EventArgs)(Function([object], args)
                                                                                             tTest = True
 
                                                                                         End Function))
 
-            tDyanmic.OnEvent(Nothing, Nothing)
+            tDynamic.OnEvent(Nothing, Nothing)
 
             Assert.AreEqual(True, tTest)
 
-            Impromptu.InvokeAddAssign(tDyanmic, "Prop2", 4)
+            Impromptu.InvokeAddAssign(tDynamic, "Prop2", 4)
 
-            Assert.AreEqual(7L, tDyanmic.Prop2)
+            Assert.AreEqual(7L, tDynamic.Prop2)
         End Sub
 
         <Test()> _
         Public Sub TestCacheableDynamicAddAssign()
-            Dim tDyanmic = Build.NewObject(Prop2:=3, [Event]:=Nothing, OnEvent:=New ThisAction(Of Object, EventArgs)(Function(this, obj, args) this.[Event](obj, args)))
+            Dim tDynamic = Build.NewObject(Prop2:=3, [Event]:=Nothing, OnEvent:=New ThisAction(Of Object, EventArgs)(Function(this, obj, args) this.[Event](obj, args)))
             Dim tDynamic2 = Build.NewObject([Event]:=3)
             Dim tTest As Boolean = False
 
             Dim tCachedInvoke = New CacheableInvocation(InvocationKind.AddAssign, "Event")
 
-            tCachedInvoke.Invoke(DirectCast(tDyanmic, Object), New EventHandler(Of EventArgs)(Function([object], args)
+            tCachedInvoke.Invoke(DirectCast(tDynamic, Object), New EventHandler(Of EventArgs)(Function([object], args)
                                                                                                   tTest = True
 
                                                                                               End Function))
 
-            tDyanmic.OnEvent(Nothing, Nothing)
+            tDynamic.OnEvent(Nothing, Nothing)
 
             Assert.AreEqual(True, tTest)
 

--- a/Tests/UnitTestImpromptuInterface/SingleMethodInvoke.cs
+++ b/Tests/UnitTestImpromptuInterface/SingleMethodInvoke.cs
@@ -88,7 +88,7 @@ namespace UnitTestImpromptuInterface
              }
 
              [Test]
-             public void TestCacheableDyanmicSetAndPocoSetAndSetNull()
+             public void TestCacheableDynamicSetAndPocoSetAndSetNull()
              {
                  dynamic tExpando = new ExpandoObject();
                  var tSetValueD = "4";
@@ -1232,32 +1232,32 @@ namespace UnitTestImpromptuInterface
          [Test]
          public void TestDynamicAddAssign()
          {
-             var tDyanmic = Build.NewObject(Prop2: 3, Event: null, OnEvent: new ThisAction<object, EventArgs>((@this, obj, args) => @this.Event(obj, args)));
+             var tDynamic = Build.NewObject(Prop2: 3, Event: null, OnEvent: new ThisAction<object, EventArgs>((@this, obj, args) => @this.Event(obj, args)));
              bool tTest = false;
 
-             Impromptu.InvokeAddAssignMember(tDyanmic, "Event", new EventHandler<EventArgs>((@object, args) => { tTest = true; }));
+             Impromptu.InvokeAddAssignMember(tDynamic, "Event", new EventHandler<EventArgs>((@object, args) => { tTest = true; }));
 
-             tDyanmic.OnEvent(null, null);
+             tDynamic.OnEvent(null, null);
 
              Assert.AreEqual(true, tTest);
 
-             Impromptu.InvokeAddAssignMember(tDyanmic, "Prop2", 4);
+             Impromptu.InvokeAddAssignMember(tDynamic, "Prop2", 4);
 
-             Assert.AreEqual(7L, tDyanmic.Prop2);
+             Assert.AreEqual(7L, tDynamic.Prop2);
          }
 
          [Test]
          public void TestCacheableDynamicAddAssign()
          {
-             var tDyanmic = Build.NewObject(Prop2: 3, Event: null, OnEvent: new ThisAction<object, EventArgs>((@this, obj, args) => @this.Event(obj, args)));
+             var tDynamic = Build.NewObject(Prop2: 3, Event: null, OnEvent: new ThisAction<object, EventArgs>((@this, obj, args) => @this.Event(obj, args)));
              var tDynamic2 = Build.NewObject(Event: 3);
              bool tTest = false;
 
              var tCachedInvoke = new CacheableInvocation(InvocationKind.AddAssign, "Event");
 
-             tCachedInvoke.Invoke((object) tDyanmic, new EventHandler<EventArgs>((@object, args) => { tTest = true; }));
+             tCachedInvoke.Invoke((object) tDynamic, new EventHandler<EventArgs>((@object, args) => { tTest = true; }));
 
-             tDyanmic.OnEvent(null, null);
+             tDynamic.OnEvent(null, null);
 
              Assert.AreEqual(true, tTest);
 
@@ -1269,29 +1269,29 @@ namespace UnitTestImpromptuInterface
          [Test]
          public void TestDynamicSubtractAssign()
          {
-             var tDyanmic = Build.NewObject(Prop2: 3, Event: null, OnEvent: new ThisAction<object, EventArgs>((@this, obj, args) => @this.Event(obj, args)));
+             var tDynamic = Build.NewObject(Prop2: 3, Event: null, OnEvent: new ThisAction<object, EventArgs>((@this, obj, args) => @this.Event(obj, args)));
              bool tTest = false;
              var tEvent = new EventHandler<EventArgs>((@object, args) => { tTest = true; });
 
-             tDyanmic.Event += tEvent;
+             tDynamic.Event += tEvent;
 
-             Impromptu.InvokeSubtractAssignMember(tDyanmic, "Event", tEvent);
+             Impromptu.InvokeSubtractAssignMember(tDynamic, "Event", tEvent);
 
-             tDyanmic.OnEvent(null, null);
+             tDynamic.OnEvent(null, null);
 
              Assert.AreEqual(false, tTest);
 
 
-             Impromptu.InvokeSubtractAssignMember(tDyanmic, "Prop2", 4);
+             Impromptu.InvokeSubtractAssignMember(tDynamic, "Prop2", 4);
 
-             Assert.AreEqual(-1L, tDyanmic.Prop2);
+             Assert.AreEqual(-1L, tDynamic.Prop2);
          }
 
 
          [Test]
          public void TestCacheableDynamicSubtractAssign()
          {
-             var tDyanmic = Build.NewObject(Prop2: 3, Event: null, OnEvent: new ThisAction<object, EventArgs>((@this, obj, args) => @this.Event(obj, args)));
+             var tDynamic = Build.NewObject(Prop2: 3, Event: null, OnEvent: new ThisAction<object, EventArgs>((@this, obj, args) => @this.Event(obj, args)));
              var tDynamic2 = Build.NewObject(Event: 3);
 
              bool tTest = false;
@@ -1299,11 +1299,11 @@ namespace UnitTestImpromptuInterface
            
              var tCachedInvoke = new CacheableInvocation(InvocationKind.SubtractAssign, "Event");
 
-             tDyanmic.Event += tEvent;
+             tDynamic.Event += tEvent;
 
-             tCachedInvoke.Invoke((object) tDyanmic, tEvent);
+             tCachedInvoke.Invoke((object) tDynamic, tEvent);
 
-             tDyanmic.OnEvent(null, null);
+             tDynamic.OnEvent(null, null);
 
              Assert.AreEqual(false, tTest);
 


### PR DESCRIPTION
This fixes all the places `dyanmic` was written instead of `dynamic`.