### PR TITLE
Fix version conflicts caused by PR#39

### DIFF
--- a/ImpromptuInterface/ImpromptuInterface.csproj
+++ b/ImpromptuInterface/ImpromptuInterface.csproj
@@ -25,6 +25,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.Reflection.Emit" Version="4.3.*" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.*" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.6.*" />
   </ItemGroup>
 </Project>

--- a/Tests/UnitTestImpromptuInterface.Clay/UnitTestImpromptuInterface.Clay.csproj
+++ b/Tests/UnitTestImpromptuInterface.Clay/UnitTestImpromptuInterface.Clay.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Castle.Core" Version="1.1.*" />
     <PackageReference Include="Castle.DynamicProxy" Version="2.1.*" />
     <PackageReference Include="IronPython" Version="2.7.*" />
-    <PackageReference Include="log4net" Version="1.2.10" />
+    <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="Clay" Version="1.0" />
   </ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump log4net from 1.2.10 to 2.0.10. [(PR#39)](https://github.com/ekonbenefits/impromptu-interface/pull/39).
Hope this fix can help you.

Best regards,
sucrose