### PR TITLE
Bump to NET46

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 install:
   - cmd: git submodule update --init --recursive

--- a/ImpromptuInterface/ImpromptuInterface.csproj
+++ b/ImpromptuInterface/ImpromptuInterface.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <Description>A Lightweight Duck Casting Framework for dynamic C#</Description>
@@ -10,7 +10,7 @@
     <PackageProjectUrl>https://github.com/ekonbenefits/impromptu-interface</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/ekonbenefits/impromptu-interface/blob/master/License.txt</PackageLicenseUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/ekonbenefits/impromptu-interface/master/graphics/ImpromptuInterface-Icon.png</PackageIconUrl>
-    <PackageTags>ducktyping duckcasting dynamic .net40 Silverlight proxy impromptu interface reflection dlr currying</PackageTags>
+    <PackageTags>ducktyping duckcasting dynamic .net46 Silverlight proxy impromptu interface reflection dlr currying</PackageTags>
     <IncludeSymbols>True</IncludeSymbols>
     <IncludeSource>True</IncludeSource>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -19,8 +19,9 @@
   <Import Project="..\Version.props" />
   <ItemGroup>
     <PackageReference Include="Dynamitey" Version="2.0.*" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net46'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/ImpromptuInterface/src/EmitProxy/BuildProxy.cs
+++ b/ImpromptuInterface/src/EmitProxy/BuildProxy.cs
@@ -78,7 +78,7 @@ namespace ImpromptuInterface.Build
         }
 
 
-#if NET40
+#if NET46
 
         internal class TempBuilder : IDisposable
         {

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-net4.0/netstd2.0 framework to allow you to wrap any object (static or dynamic) with a static interface even though it didn't inherit from it. It does this by emitting cached dynamic binding code inside a proxy.
+net4.6/netstd2.0 framework to allow you to wrap any object (static or dynamic) with a static interface even though it didn't inherit from it. It does this by emitting cached dynamic binding code inside a proxy.
 
 ImpromptuInterface is available Nuget [![NuGet](https://img.shields.io/nuget/dt/ImpromptuInterface.svg)](https://www.nuget.org/packages/ImpromptuInterface/)
 


### PR DESCRIPTION
Build process seemed broken while working on https://github.com/ekonbenefits/impromptu-interface/pull/49.

I bumped build .Net framework requirements to 4.6 to make this work. I don't have deep knowledge on how .Net/Core/Standard dependencies compatiblity work, so not sure what the side effects of this change would be, except that the minimum .NET version required for this package will now be 4.6.

4.5 has already reached EOL, and 4.6.2 will probably be EOL some time around 2025/2026