### PR TITLE
Make default maker constructor internal, should only be one.

### DIFF
--- a/ImpromptuInterface/src/EmitProxy/ActLikeMaker.cs
+++ b/ImpromptuInterface/src/EmitProxy/ActLikeMaker.cs
@@ -142,7 +142,7 @@ namespace ImpromptuInterface.Build
         }
 
 
-        public ActLikeMaker()
+        internal ActLikeMaker()
         {
             AssemblyAccess = AssemblyBuilderAccess.Run;
             AssemblyName = $"{nameof(ImpromptuInterface)}DynamicAssembly";

--- a/Version.props
+++ b/Version.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>8.0.2</VersionPrefix>
+        <VersionPrefix>8.0.3</VersionPrefix>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Two argument constructor ideal for public use.