### PR TITLE
Fix crash when copying custom attributes with array constructor arguments

### DIFF
--- a/ImpromptuInterface/src/EmitProxy/ActLikeMaker.cs
+++ b/ImpromptuInterface/src/EmitProxy/ActLikeMaker.cs
@@ -1433,11 +1433,36 @@ namespace ImpromptuInterface.Build
         {
             return new CustomAttributeBuilder(
                 customAttributeData.Constructor,
-                customAttributeData.ConstructorArguments.Select(arg => arg.Value).ToArray(),
-                customAttributeData.NamedArguments.Where(arg => arg.MemberInfo.MemberType == MemberTypes.Property).Select(arg => arg.MemberInfo).Cast<PropertyInfo>().ToArray(),
-                customAttributeData.NamedArguments.Where(arg => arg.MemberInfo.MemberType == MemberTypes.Property).Select(arg => arg.TypedValue.Value).ToArray(),
-                customAttributeData.NamedArguments.Where(arg => arg.MemberInfo.MemberType == MemberTypes.Field).Select(arg => arg.MemberInfo).Cast<FieldInfo>().ToArray(),
-                customAttributeData.NamedArguments.Where(arg => arg.MemberInfo.MemberType == MemberTypes.Field).Select(arg => arg.TypedValue.Value).ToArray());
+                customAttributeData.ConstructorArguments
+                    .Select(
+                        arg =>
+                            arg.Value?.GetType()
+                            == typeof(ReadOnlyCollection<CustomAttributeTypedArgument>)
+                                ? ((ReadOnlyCollection<CustomAttributeTypedArgument>)arg.Value)
+                                .Select(arrayArg => arrayArg.Value)
+                                .ToArray()
+                                : arg.Value
+                    )
+                    .ToArray(),
+                customAttributeData.NamedArguments
+                    .Where(arg => arg.MemberInfo.MemberType == MemberTypes.Property)
+                    .Select(arg => arg.MemberInfo)
+                    .Cast<PropertyInfo>()
+                    .ToArray(),
+                customAttributeData.NamedArguments
+                    .Where(arg => arg.MemberInfo.MemberType == MemberTypes.Property)
+                    .Select(arg => arg.TypedValue.Value)
+                    .ToArray(),
+                customAttributeData.NamedArguments
+                    .Where(arg => arg.MemberInfo.MemberType == MemberTypes.Field)
+                    .Select(arg => arg.MemberInfo)
+                    .Cast<FieldInfo>()
+                    .ToArray(),
+                customAttributeData.NamedArguments
+                    .Where(arg => arg.MemberInfo.MemberType == MemberTypes.Field)
+                    .Select(arg => arg.TypedValue.Value)
+                    .ToArray()
+            );
         }
 
 

--- a/Tests/UnitTestImpromptuInterface/Basic.cs
+++ b/Tests/UnitTestImpromptuInterface/Basic.cs
@@ -444,9 +444,28 @@ namespace UnitTestImpromptuInterface
         {
             dynamic tNew = new ExpandoObject();
             ISimpeleSetClassProps tActsLike = Impromptu.ActLike<ISimpeleSetClassProps>(tNew);
-            var attribute = (DisplayNameAttribute)tActsLike.GetType().GetProperty(nameof(ISimpeleSetClassProps.Prop1)).GetCustomAttribute(typeof(DisplayNameAttribute), true);
+            var attribute = (DisplayNameAttribute)
+                tActsLike
+                    .GetType()
+                    .GetProperty(nameof(ISimpeleSetClassProps.Prop1))
+                    .GetCustomAttribute(typeof(DisplayNameAttribute), true);
             Assert.NotNull(attribute);
             Assert.AreEqual("testDisplayName", attribute.DisplayName);
+        }
+
+        [Test]
+        public void PropertyAttributeWithArrayArgumentTest()
+        {
+            dynamic tNew = new ExpandoObject();
+            ISimpeleSetClassProps tActsLike = Impromptu.ActLike<ISimpeleSetClassProps>(tNew);
+            var attribute = (DisplayNamesAttribute)
+                tActsLike
+                    .GetType()
+                    .GetProperty(nameof(ISimpeleSetClassProps.Prop2))
+                    .GetCustomAttribute(typeof(DisplayNamesAttribute), true);
+            Assert.NotNull(attribute);
+            Assert.AreEqual("testDisplayName1", attribute.DisplayNames[0]);
+            Assert.AreEqual("testDisplayName2", attribute.DisplayNames[1]);
         }
 
         [Test]

--- a/Tests/UnitTestImpromptuInterface/Basic.cs
+++ b/Tests/UnitTestImpromptuInterface/Basic.cs
@@ -654,6 +654,15 @@ namespace UnitTestImpromptuInterface
             Assert.AreEqual(true, tOut);
             Assert.AreEqual(4, tResult2);
         }
+
+        [Test]
+        public void GenericStructInNullableContextTest()
+        {
+            var result = new
+            {
+                SomeOtherProperty = "test"
+            }.ActLike<IInterfaceWithGenericStructProperty>();
+        }
     }
 }
 

--- a/Tests/UnitTestImpromptuInterface/Support/SupportDefinitions.cs
+++ b/Tests/UnitTestImpromptuInterface/Support/SupportDefinitions.cs
@@ -577,4 +577,27 @@ namespace UnitTestImpromptuInterface
         }
     }
 
+#if NET6_0_OR_GREATER
+#nullable enable
+#endif
+    public struct GenericStruct<T>
+    {
+        public string Something { get; }
+
+        public GenericStruct(string something)
+        {
+            Something = something;
+        }
+    }
+
+    public interface IInterfaceWithGenericStructProperty
+    {
+        GenericStruct<IInterfaceWithGenericStructProperty> StructProperty { get; }
+
+        string SomeOtherProperty { get; }
+    }
+#if NET6_0_OR_GREATER
+#nullable restore
+#endif
+
 }

--- a/Tests/UnitTestImpromptuInterface/Support/SupportDefinitions.cs
+++ b/Tests/UnitTestImpromptuInterface/Support/SupportDefinitions.cs
@@ -102,11 +102,22 @@ namespace UnitTestImpromptuInterface
         Guid Prop3 { get; }
     }
 
+    public class DisplayNamesAttribute : Attribute
+    {
+        public string[] DisplayNames { get; }
+
+        public DisplayNamesAttribute(params string[] displayNames)
+        {
+            DisplayNames = displayNames;
+        }
+    }
+
     public interface ISimpeleSetClassProps
     {
         [DisplayName("testDisplayName")]
         string Prop1 { set ; }
 
+        [DisplayNames("testDisplayName1", "testDisplayName2")]
         long Prop2 { set; }
 
         Guid Prop3 { set; }


### PR DESCRIPTION
Fixes #56.

As noted by the [`CustomAttributeTypedArgument` docs](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.customattributetypedargument?view=net-8.0#remarks):

> If an argument is an array of values, the [Value](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.customattributetypedargument.value?view=net-8.0) property of the [CustomAttributeTypedArgument](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.customattributetypedargument?view=net-8.0) that represents the argument returns a generic [ReadOnlyCollection<T>](https://learn.microsoft.com/en-us/dotnet/api/system.collections.objectmodel.readonlycollection-1?view=net-8.0) of [CustomAttributeTypedArgument](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.customattributetypedargument?view=net-8.0) objects. Each [CustomAttributeTypedArgument](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.customattributetypedargument?view=net-8.0) object in the collection represents the corresponding element of the array.

Therefore, the code that translates the `CustomAttributeData` to `CustomAttributeBuilder` needs to convert `ReadOnlyCollection` constructor arguments to arrays. Example code showing the legitimacy of checking for `ReadOnlyCollection`s is shown in the [docs examples](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.customattributetypedargument?view=net-8.0#examples):

```csharp
private static void ShowValueOrArray(CustomAttributeTypedArgument cata)
{
    if (cata.Value.GetType() == typeof(ReadOnlyCollection<CustomAttributeTypedArgument>))
    {
        Console.WriteLine("         Array of '{0}':", cata.ArgumentType);

        foreach (CustomAttributeTypedArgument cataElement in
            (ReadOnlyCollection<CustomAttributeTypedArgument>) cata.Value)
        {
            Console.WriteLine("             Type: '{0}'  Value: '{1}'",
                cataElement.ArgumentType, cataElement.Value);
        }
    }
    else
    {
        Console.WriteLine("         Type: '{0}'  Value: '{1}'",
            cata.ArgumentType, cata.Value);
    }
}
```